### PR TITLE
Fix add product button integer parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,6 +48,12 @@ def get_products():
     return db.get_all_products()
 
 
+@app.get("/products/new", response_class=HTMLResponse)
+def new_product_page(request: Request):
+    """New product page"""
+    return templates.TemplateResponse("new.html", {"request": request})
+
+
 @app.get("/products/{product_id}", response_model=Product)
 def get_product(product_id: int):
     """Get a specific product by ID"""
@@ -156,12 +162,6 @@ def edit_product_page(request: Request, product_id: int):
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
     return templates.TemplateResponse("edit.html", {"request": request, "product": product})
-
-
-@app.get("/products/new", response_class=HTMLResponse)
-def new_product_page(request: Request):
-    """New product page"""
-    return templates.TemplateResponse("new.html", {"request": request})
 
 
 # TODO: Add search endpoint with AI-powered features


### PR DESCRIPTION
Reorder `/products/new` route and remove duplicate to fix integer parsing error.

The error occurred because FastAPI's route matching prioritizes general parameterized routes (e.g., `/products/{product_id}`) over specific literal routes (e.g., `/products/new`) if the specific route is defined later. Moving `/products/new` before `/products/{product_id}` ensures the correct route is matched, preventing "new" from being parsed as an integer.

---

[Open in Web](https://www.cursor.com/agents?id=bc-9142f4a2-525a-4476-9fb9-2e8f5ca7782e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9142f4a2-525a-4476-9fb9-2e8f5ca7782e)